### PR TITLE
Fix Cancelled interface typo

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -55,7 +55,7 @@ var (
 
 // cancelled maps to Moby's "ErrCancelled"
 type cancelled interface {
-	ErrCancelled()
+	Cancelled()
 }
 
 // IsCanceled returns true if the error is due to `context.Canceled`.


### PR DESCRIPTION
The function for the interface should be `Cancelled` not `ErrCancelled`. The intent is to match [this interface](https://github.com/moby/moby/blob/master/errdefs/defs.go#L58)