### PR TITLE
Fix stack support through an additional error type

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,6 +26,10 @@ package errdefs
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+
+	"github.com/containerd/errdefs/stack"
 )
 
 // Definitions of common error types used throughout containerd. All containerd
@@ -408,4 +412,100 @@ func (c customMessage) As(target any) bool {
 
 func (c customMessage) Error() string {
 	return c.msg
+}
+
+// errorValue is a general purpose container for errors.
+//
+// It is constructed through New and is used to ensure
+// the proper formatting behavior for the contents of
+// the error.
+type errorValue struct {
+	error
+}
+
+func (e errorValue) Format(st fmt.State, verb rune) {
+	format := fmt.FormatString(st, verb)
+	fmt.Fprintf(st, format, e.error)
+	if verb == 'v' && st.Flag('+') {
+		printStackTraces(st, e.error)
+	}
+}
+
+func (e errorValue) Unwrap() error {
+	return e.error
+}
+
+// New constructs a new error with the given format string.
+func New(format string, args ...interface{}) error {
+	return &errorValue{
+		error: fmt.Errorf(format, args...),
+	}
+}
+
+func Join(errs ...error) error {
+	return &errorValue{
+		error: errors.Join(errs...),
+	}
+}
+
+func WithStack(err error) error {
+	return &stackError{
+		error: err,
+		stack: stack.Callers(2),
+	}
+}
+
+type stackError struct {
+	error
+	stack *stack.Trace
+}
+
+func (e *stackError) Format(st fmt.State, verb rune) {
+	format := fmt.FormatString(st, verb)
+	fmt.Fprintf(st, format, e.error)
+	if verb == 'v' && st.Flag('+') {
+		fmt.Fprintln(st)
+		e.stack.Print(st)
+	}
+}
+
+func (e *stackError) Unwrap() error {
+	return e.error
+}
+
+func printStackTraces(w io.Writer, err error) {
+	// Collect all stack traces from the error.
+	// Stored in a stack for efficiency and to prevent
+	// a recursive stack from piling up.
+	unvisited := []error{err}
+	for len(unvisited) > 0 {
+		// Pop the end.
+		cur := unvisited[len(unvisited)-1]
+		unvisited = unvisited[:len(unvisited)-1]
+
+		// Print the stack trace if this is one.
+		if se, ok := cur.(*stackError); ok {
+			fmt.Fprintf(w, "\n\nCaused by: %v\n", se)
+			se.stack.Print(w)
+		}
+
+		switch cur := cur.(type) {
+		case interface{ Unwrap() error }:
+			if err := cur.Unwrap(); err != nil {
+				unvisited = append(unvisited, err)
+			}
+		case interface{ Unwrap() []error }:
+			errs := cur.Unwrap()
+			if len(errs) > 0 {
+				// Append in the proper order just for
+				// memory efficiency and then reverse the
+				// contents since we want to pop the first
+				// error first.
+				unvisited = append(unvisited, errs...)
+				for i, j := len(unvisited)-len(errs), len(unvisited)-1; i < j; i, j = i+1, j-1 {
+					unvisited[i], unvisited[j] = unvisited[j], unvisited[i]
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Stack support was included but didn't work properly when outputting the format. The intention was for `%+v` to be used when the stack should show up, but this didn't work properly because `errors.Join` and `fmt.Errorf` don't pass the `%+v` through when constructing the output.

This updates the library to include a `New` method that works the exact same as `fmt.Errorf` and uses `fmt.Errorf` on the backend. It wraps the output of that with an `errorValue` and `errorValue` properly handles the formatting directive for the underlying stacks.

Stacks are also included by wrapping an error using `WithStack` rather than using `errors.Join`. `errors.Join` would always create a newline for the error and didn't have a way to hide the stack trace depending on the formatting directive. We now just embed the stack trace with the error and `errorValue` is what handles extracting the stacks.