### PR TITLE
Refactor errdefs with an API more similar to the standard library

### DIFF
--- a/join.go
+++ b/join.go
@@ -1,0 +1,74 @@
+package errdefs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containerd/errdefs/internal/types"
+)
+
+type joinError struct {
+	errs []error
+}
+
+// Join will join the errors together and ensure stack traces
+// are appropriately formatted.
+func Join(errs ...error) error {
+	var e error
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			e = err
+			n++
+		}
+	}
+
+	switch n {
+	case 0:
+		return nil
+	case 1:
+		switch e.(type) {
+		case *errorValue, *joinError:
+			// Don't wrap the types defined by this package
+			// as that could interfere with the formatting.
+			return e
+		}
+		return &errorValue{e}
+	}
+
+	joined := make([]error, 0, n)
+	for _, err := range errs {
+		if err != nil {
+			joined = append(joined, err)
+		}
+	}
+	return &joinError{errs: joined}
+}
+
+func (e *joinError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%v", e)
+	return b.String()
+}
+
+func (e *joinError) Format(st fmt.State, verb rune) {
+	format := fmt.FormatString(st, verb)
+	collapsed := verb == 'v' && st.Flag('+')
+	first := true
+	for _, err := range e.errs {
+		if !collapsed {
+			if _, ok := err.(types.CollapsibleError); ok {
+				continue
+			}
+		}
+		if !first {
+			fmt.Fprintln(st)
+		}
+		fmt.Fprintf(st, format, err)
+		first = false
+	}
+}
+
+func (e *joinError) Unwrap() []error {
+	return e.errs
+}

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -17,7 +17,6 @@
 package stack
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -56,7 +55,6 @@ func TestCollapsed(t *testing.T) {
 	expected := "some error"
 	checkError(Join(errors.New(expected)), expected)
 	checkError(Join(errors.New(expected), ErrStack()), expected)
-	checkError(WithStack(context.Background(), errors.New(expected)), expected)
 }
 
 func TestHelpers(t *testing.T) {
@@ -90,9 +88,8 @@ func TestHelpers(t *testing.T) {
 
 func testHelper(msg string, withHelper bool) error {
 	if withHelper {
-		return WithStack(WithHelper(context.Background()), errors.New(msg))
+		return Join(errors.New(msg), Callers(2))
 	} else {
-		return WithStack(context.Background(), errors.New(msg))
+		return Join(errors.New(msg), ErrStack())
 	}
-
 }


### PR DESCRIPTION
This updates errdefs to have an API similar to the standard library. The `New` method is the equivalent of `fmt.Errorf` and `Join` is the equivalent of `errors.Join`.

These methods also support the proper output of stack traces by ensuring the proper handling of the formatting for collapsible errors.

Similarly, the `stack` package has been updated to remove the context-based helper and instead directly expose the function that creates the stack error. The stack error is also renamed to `Error` and exposed rather than left unexported.

The `stack` package can be used to directly create errors with stacks when one isn't present. It is also possible to add multiple stacks to a single error through `errdefs.Join` and `errdefs.ErrStack` to manually create a stack error.